### PR TITLE
DT-864 Make timeout configurable per resource.

### DIFF
--- a/lib/served/http_client.rb
+++ b/lib/served/http_client.rb
@@ -5,15 +5,16 @@ module Served
     HEADERS = { 'Content-type' => 'application/json', 'Accept' => 'application/json' }
     DEFAULT_TEMPLATE = '{/resource*}{/id}.json{?query*}'
 
-    def initialize(host)
+    def initialize(host, timeout)
       host += DEFAULT_TEMPLATE unless host =~ /{.+}/
       @template = Addressable::Template.new(host)
+      @timeout  = timeout
     end
 
     def get(endpoint, id, params={})
       HTTParty.get(@template.expand(id: id, query: params, resource: endpoint).to_s,
                    headers: HEADERS,
-                   timeout: Served.config.timeout
+                   timeout: @timeout
       )
     end
 
@@ -21,7 +22,7 @@ module Served
       HTTParty.put(@template.expand(id: id, query: params, resource: endpoint).to_s,
         body:    body,
         headers: HEADERS,
-        timeout: Served.config.timeout
+        timeout: @timeout
       )
     end
 
@@ -29,7 +30,7 @@ module Served
       HTTParty.post(@template.expand(query: params, resource: endpoint).to_s,
         body:    body,
         headers: HEADERS,
-        timeout: Served.config.timeout
+        timeout: @timeout
       )
     end
   end

--- a/lib/served/resource/base.rb
+++ b/lib/served/resource/base.rb
@@ -53,10 +53,15 @@ module Served
           Served.config[:hosts][parent.name.underscore.split('/')[-1]]
         end
 
+        # @return [Integer] allowed timeout in seconds
+        def timeout
+          Served.config.timeout
+        end
+
         # @return [Served::HTTPClient] The connection instance to the service host. Note this is not an active
         # connection but a passive one.
         def client
-          @connection ||= Served::HTTPClient.new(host_config)
+          @connection ||= Served::HTTPClient.new(host_config, timeout)
         end
 
         private

--- a/lib/served/version.rb
+++ b/lib/served/version.rb
@@ -1,3 +1,3 @@
 module Served
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 describe Served::HTTPClient do
-  subject { Served::HTTPClient.new('http://host') }
+  subject { Served::HTTPClient.new('http://host', Served.config.timeout) }
 
   context 'with an addressable template' do
-    subject { Served::HTTPClient.new('http://host/{resource}.foo') }
+    subject { Served::HTTPClient.new('http://host/{resource}.foo', Served.config.timeout) }
 
      it 'does not use the default config template' do
        expect(subject.instance_variable_get(:@template).


### PR DESCRIPTION
Now the timeout can be specified on the resource level by overriding the static `timeout` method. If not overridden, it defaults to `Served.config.timeout` so this change maintains backwards compatibility.
