### PR TITLE
Bugfix for backwards compatibility

### DIFF
--- a/lib/served/resource/requestable.rb
+++ b/lib/served/resource/requestable.rb
@@ -72,11 +72,11 @@ module Served
             if handler.is_a? Proc
               result = handler.call(response)
             else
-              result = send(handler, response)
+              result = send(handler, response.body)
             end
-            if result.is_a?(HttpError)
+
+            if result.respond_to?(:ancestors) && result.ancestors.include?(HttpError)
               raise result.new(self, response)
-              result = Served::Serializers::JsonApi::Errors.new(response)
             end
             result
           else

--- a/lib/served/version.rb
+++ b/lib/served/version.rb
@@ -1,3 +1,3 @@
 module Served
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/resource/requestable_spec.rb
+++ b/spec/resource/requestable_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+describe Served::Resource::Base do
+  let(:test_host) { 'http://testhost:3000' }
+  let(:body) { '{"id": 1, "first_name": "Foo"}' }
+  let(:response_code) { 200 }
+  let(:response) { double(body: body, code: response_code) }
+  let(:client) { double(get: response) }
+
+  let(:klass) do
+    Class.new(Served::Resource::Base) do
+      attribute :id
+      attribute :first_name
+
+      def self.name
+        'SomeModule::ResourceTest'
+      end
+    end
+  end
+
+  class JsonApiResource < Served::Resource::Base
+    def self.raise_on_exceptions
+      false
+    end
+  end
+
+  before :each do
+    Served.configure do |c|
+      c.hosts = { default: test_host }
+    end
+  end
+
+  subject { klass }
+
+  describe '#handle_response' do
+
+    describe '200' do
+      it 'calls load' do
+        expect(subject).to receive(:load)
+        subject.handle_response(response)
+      end
+    end
+
+    describe '204' do
+      let(:response_code) { 204 }
+
+      it 'returns attributes' do
+        expect(subject.handle_response(response)).to eq({ id: {}})
+      end
+    end
+
+    describe 'error codes' do
+      let(:response_code) { 301 }
+
+      it 'raises an exception' do
+        expect do
+          subject.handle_response(response)
+        end.to raise_exception Served::Resource::MovedPermanently
+      end
+    end
+
+    describe 'do not raise on exceptions' do
+      let(:response_code) { 301 }
+      subject { JsonApiResource }
+
+      it 'raises an exception' do
+          expect(subject.serializer).to receive(:load)
+          subject.handle_response(response)
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
* Exceptions have not be raised anymore because of failing if clause.
* handler expecting response body not response object.
* Added specs