### PR TITLE
Gracefully handle empty response body in case of a failed request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.1
+* Fixes unhandled exception when error response isn't valid JSON
+
 ## 0.4.0
 * Install rubocop and make everything compliant.
 * Improve error messaging for inclusion validations.

--- a/lib/served/serializers/json.rb
+++ b/lib/served/serializers/json.rb
@@ -26,6 +26,8 @@ module Served
 
       def self.exception(data)
         JSON.parse(data)
+      rescue
+        {}
       end
     end
   end

--- a/lib/served/version.rb
+++ b/lib/served/version.rb
@@ -1,3 +1,3 @@
 module Served
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/lib/served/version.rb
+++ b/lib/served/version.rb
@@ -1,3 +1,3 @@
 module Served
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/resource/requestable_spec.rb
+++ b/spec/resource/requestable_spec.rb
@@ -55,6 +55,17 @@ describe Served::Resource::Base do
           subject.handle_response(response)
         end.to raise_exception Served::Resource::MovedPermanently
       end
+
+      context 'with an empty response body' do
+        let(:response_code) { 408 }
+        let(:response) { double(body: '', code: response_code) }
+
+        it 'raises an exception' do
+          expect do
+            subject.handle_response(response)
+          end.to raise_exception Served::Resource::RequestTimeout
+        end
+      end
     end
 
     describe 'do not raise on exceptions' do


### PR DESCRIPTION
When the response's body doesn't contain valid JSON (e.g. an nginx error page, Fastly,...), we currently fail with an `JSON::ParserError`, instead of raising the actual HTTP exception.

This PR fixes that by introducing a `rescue` block in `Served::Serializers::Json.exception`