### PR TITLE
Handle all HTTP status codes

### DIFF
--- a/lib/served/resource/http_errors.rb
+++ b/lib/served/resource/http_errors.rb
@@ -7,24 +7,20 @@ module Served
       attr_reader :response
       attr_reader :code
 
-      # Defined in individual error classes
-      def self.code
-        raise NotImplementedError
-      end
+      def initialize(code, resource, response)
+        @code = code
 
-      def initialize(resource, response)
         if resource.serializer.respond_to? :exception
           serialized = resource.serializer.exception(response.body).symbolize_keys!
 
           @error            = serialized[:error]
           @message          = serialized[:exception]
           @server_backtrace = serialized[:backtrace]
-          @code             = serialized[:code] || serialized[:code] = self.class.code
           @response         = OpenStruct.new(serialized) # TODO: remove in served 1.0, used for backwards compat
 
           super("An error '#{code} #{message}' occurred while making this request")
         end
-        super "An error occurred '#{self.class.code}'"
+        super "An error occurred '#{code}'"
       end
 
       def status
@@ -32,81 +28,60 @@ module Served
       end
     end
 
-    # 301 MovedPermanently
-    class MovedPermanently < HttpError
-      def self.code
-        301
-      end
+    # 302, 303, 307
+    class Redirection < HttpError
     end
 
-    # 400 BadRequest
-    class BadRequest < HttpError
-      def self.code
-        400
-      end
+    # 301 Moved Permanently
+    class MovedPermanently < Redirection
+    end
+
+    # 401-499
+    class ClientError < HttpError
+    end
+
+    # 400 Bad Request
+    class BadRequest < ClientError
     end
 
     # 401 Unauthorized
-    class Unauthorized < HttpError
-      def self.code
-        401
-      end
+    class Unauthorized < ClientError
     end
 
     # 403 Forbidden
-    class Forbidden < HttpError
-      def self.code
-        403
-      end
+    class Forbidden < ClientError
     end
 
-    # 404 NotFound
-    class NotFound < HttpError
-      def self.code
-        404
-      end
+    # 404 Not Found
+    class NotFound < ClientError
     end
 
-    # 405 MethodNotAllowed
-    class MethodNotAllowed < HttpError
-      def self.code
-        405
-      end
+    # 405 Method Not Allowed
+    class MethodNotAllowed < ClientError
     end
 
-    # 406 NotAcceptable
-    class NotAcceptable < HttpError
-      def self.code
-        406
-      end
+    # 406 Not Acceptable
+    class NotAcceptable < ClientError
     end
 
-    # 408 RequestTimeout
-    class RequestTimeout < HttpError
-      def self.code
-        408
-      end
+    # 408 Request Timeout
+    class RequestTimeout < ClientError
     end
 
-    # 422 UnprocessableEntity
-    class UnprocessableEntity < HttpError
-      def self.code
-        422
-      end
+    # 422 Unprocessable Entity
+    class UnprocessableEntity < ClientError
     end
 
-    # 500 InternalServerError
-    class InternalServerError < HttpError
-      def self.code
-        500
-      end
+    # 5xx Server Error
+    class ServerError < HttpError
     end
 
-    # 503 BadGateway
-    class BadGateway < HttpError
-      def self.code
-        503
-      end
+    # 500 Internal Server Error
+    class InternalServerError < ServerError
+    end
+
+    # 503 Bad Gateway
+    class BadGateway < ServerError
     end
   end
 end

--- a/lib/served/resource/requestable.rb
+++ b/lib/served/resource/requestable.rb
@@ -67,7 +67,7 @@ module Served
       module ClassMethods
         def handle_response(response)
           if raise_on_exceptions
-            handler = handlers[response.code]
+            handler = handlers.fetch(response.code) { proc { HttpError } }
             if handler.is_a? Proc
               result = handler.call(response)
             else

--- a/lib/served/resource/requestable.rb
+++ b/lib/served/resource/requestable.rb
@@ -94,7 +94,7 @@ module Served
           raise HandlerRequired unless symbol_or_proc || block_given?
           if code_or_range.is_a?(Range) || code_or_range.is_a?(Array)
             code_or_range.each do |c|
-              handlers[c] = symbol_or_proc || block
+              handlers[c] = symbol_or_proc || block unless handlers.key?(c)
             end
           else
             handlers[code_or_range] = symbol_or_proc || block

--- a/spec/resource/requestable_spec.rb
+++ b/spec/resource/requestable_spec.rb
@@ -78,6 +78,17 @@ describe Served::Resource::Base do
       end
     end
 
+    describe 'unknown error codes' do
+      let(:response_code) { 601 }
+
+      it 'raises an exception' do
+        expect { subject.handle_response(response) }.to raise_exception do |exception|
+          expect(exception).to be_a(Served::Resource::HttpError)
+          expect(exception.code).to eq 601
+        end
+      end
+    end
+
     describe 'do not raise on exceptions' do
       let(:response_code) { 301 }
       subject { JsonApiResource }

--- a/spec/resource/requestable_spec.rb
+++ b/spec/resource/requestable_spec.rb
@@ -68,6 +68,16 @@ describe Served::Resource::Base do
       end
     end
 
+    describe 'generic error codes' do
+      let(:response_code) { 504 }
+
+      it 'raises an exception' do
+        expect do
+          subject.handle_response(response)
+        end.to raise_exception Served::Resource::ServerError
+      end
+    end
+
     describe 'do not raise on exceptions' do
       let(:response_code) { 301 }
       subject { JsonApiResource }


### PR DESCRIPTION
First shot to handle _all_ HTTP status codes.

- Defines generic error classes (`ServerError`, `ClientError`, `Redirection`)
- Installs a fallback handler that will just return an `HttpError` if a code that's not defined should be handled

Let me know what you think!