### PR TITLE
DT-2292 Fix custom error message bug.

### DIFF
--- a/lib/served/resource/http_errors.rb
+++ b/lib/served/resource/http_errors.rb
@@ -18,8 +18,9 @@ module Served
           @server_backtrace = serialized[:backtrace]
           @response         = OpenStruct.new(serialized) # TODO: remove in served 1.0, used for backwards compat
 
-          super("An error '#{code} #{message}' occurred while making this request")
+          return super("An error '#{code} #{message}' occurred while making this request")
         end
+
         super "An error occurred '#{code}'"
       end
 

--- a/lib/served/resource/http_errors.rb
+++ b/lib/served/resource/http_errors.rb
@@ -18,10 +18,10 @@ module Served
           @server_backtrace = serialized[:backtrace]
           @response         = OpenStruct.new(serialized) # TODO: remove in served 1.0, used for backwards compat
 
-          return super("An error '#{code} #{message}' occurred while making this request")
+          super("An error '#{code} #{message}' occurred while making this request")
+        else
+          super "An error occurred '#{code}'"
         end
-
-        super "An error occurred '#{code}'"
       end
 
       def status

--- a/lib/served/version.rb
+++ b/lib/served/version.rb
@@ -1,3 +1,3 @@
 module Served
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.2'.freeze
 end


### PR DESCRIPTION
Before: It would call the first `super` in the `if` block then call and return the second `super` with the default (non-custom) error message.
Now: It returns the first `super` custom error message if applicable.