### PR TITLE
DT-4008: fixed deprecated Fixnum warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,3 @@ Metrics/BlockLength:
 
 Lint/UnifiedInteger:
   Enabled: false
-
-Performance/RegexpMatch:
-  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.2.7
   - 2.3.2
   - 2.3.4
+  - 2.4.0
   - 2.4.1
 before_install: gem install bundler -v 1.10.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
 language: ruby
 rvm:
-  - 2.1.9
-  - 2.1.10
-  - 2.2.7
-  - 2.3.2
-  - 2.3.4
   - 2.4.0
-  - 2.4.1
-before_install: gem install bundler -v 1.10.5
+before_install: gem install bundler -v 2.2.0
 
 gemfile:
   - gemfiles/3.2.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.4
+* Fixed Fixnum is deprecated warning.
+
 ## 0.4.3
 * Fix rubocop failures.
 
@@ -49,7 +52,7 @@
 * various refactoring
 * add `validation_on_save` option to allow skipping validation on save
 * better configuration inheritance in resources
-* if using HTTParty as a backend `Errno::ECONNREFUSED` will no longer be returned for connection errors, 
+* if using HTTParty as a backend `Errno::ECONNREFUSED` will no longer be returned for connection errors,
 `Served::HTTPClient::ConnectionFailed` will be raised instead
 
 ## 0.1.12
@@ -60,7 +63,7 @@
  * add resource level `reasource_name` option
  * add resource level `host` option, `host_config` will be deprecated in 0.2.0
  * add `Served::Attribute::Base` class
- 
+
 ## 0.1.11
  * add resource level `reasource_name` option
  * add resource level `host` option

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Served.configure do |config|
   config.hosts = {
     'some_service' => 'http://localhost:3000'
    }
-   
+
    config.timeout = 100
-   
+
    config.backend = :patron
    config.serializer = Served::Serializers::Json
 end
@@ -30,7 +30,7 @@ end
 
 ## Hosts
 Served models derive their hostname by mapping their parent module to the `Served::hosts` configuration hash. For
-example, `SomeService::SomeResource` would look up its host configuration at 
+example, `SomeService::SomeResource` would look up its host configuration at
 `Served.config.hosts['some_service']`.
 
 The host configuration accepts an [Addressable](https://github.com/sporkmonger/addressable) template mapping
@@ -48,8 +48,8 @@ maintained for backwards compatibility, however the extension will likely be rem
 Sets the request timeout in milliseconds.
 
 ## Backend
-Configure the HTTP client backend. Supports either :http (default), which will use the HTTP client, or :patron, which 
-will use Patron. Patron is suggested for use if high concurrency between requests is required. Also requires the 
+Configure the HTTP client backend. Supports either :http (default), which will use the HTTP client, or :patron, which
+will use Patron. Patron is suggested for use if high concurrency between requests is required. Also requires the
 machine to have libcurl.
 
 # Defining a Resource
@@ -76,14 +76,14 @@ options are:
 ## Serialization
 
 Attributes can be serialized as Ruby objects when the `serialize:` option is passed to `#attribute`. This can be any
-primitive object (`Fixnum`, `String`, `Symbol`, etc.) or any object whose initializer accepts a single `Hash` or `Array`
-as an argument and responds to `to_json`. This also means that Served resources can be used as nested objects as well, 
+primitive object (`Integer`, `String`, `Symbol`, etc.) or any object whose initializer accepts a single `Hash` or `Array`
+as an argument and responds to `to_json`. This also means that Served resources can be used as nested objects as well,
 which can allow for strict request validation (as explained in the next section).
 
 When `#save` is called on a resource, non primitive objects will be serialized for transport using their `to_json`
 method, this also means that attributes can be valid `ActiveRecord` objects. Served provides a generic validatable
-non-resource class called `Served::Attribute::Base` that can be used to define deep nested object mapping for 
-complex json data strucutres. 
+non-resource class called `Served::Attribute::Base` that can be used to define deep nested object mapping for
+complex json data strucutres.
 
 Example:
 
@@ -97,9 +97,9 @@ class SomeService::SomeResource < Served::Resource::Base
 end
 ```
 
-## JsonAPI 
+## JsonAPI
 
-Served does support JSON API responses and comes with a dedicated serializer. Nested resources are supported as well. 
+Served does support JSON API responses and comes with a dedicated serializer. Nested resources are supported as well.
 By default `Served` is raising exceptions on error.
 
 ```ruby
@@ -127,9 +127,9 @@ end
 
 
 ## Validations
-`Served::Resource::Base` includes `AciveModel::Validations` and supports all validation methods with the exception of 
-`Uniquness`. As a shotcut validations can be passed to the `#attribute` method much in the same way as it can be passed 
-to the `#validate` method. 
+`Served::Resource::Base` includes `AciveModel::Validations` and supports all validation methods with the exception of
+`Uniquness`. As a shotcut validations can be passed to the `#attribute` method much in the same way as it can be passed
+to the `#validate` method.
 
 Example:
 
@@ -137,7 +137,7 @@ Example:
 class SomeService::SomeResource < Served::Resource::Base
   attribute :name, presence: true, format: {with: /[a-z]+/}, length: { within: (3..10) }
   attribute :date
-  
+
   validates_each :date do |record, attr, value|
     # ...
    end
@@ -170,9 +170,9 @@ a resource is new or not based on the presence of an id.
 
 ### Service Errors
 
-If the service returns an error, by default an error is thrown. If you want it to behave more like AR where you get 
+If the service returns an error, by default an error is thrown. If you want it to behave more like AR where you get
 validation errors and a `save` returns `true` or `false`, you can configure that.
- 
+
 
 ```ruby
 class JsonApiResource < Served::Resource::Base
@@ -180,4 +180,4 @@ class JsonApiResource < Served::Resource::Base
     false
   end
 end
-``` 
+```

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'activesupport', '~> 3.2'
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'activesupport', '~> 4.2'
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'activesupport', '~> 5.0'
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/lib/served/backends.rb
+++ b/lib/served/backends.rb
@@ -4,8 +4,8 @@ module Served
     # @private
     def self.[](backend)
       @backends ||= {
-        http:     'HTTP',
-        patron:   'Patron',
+        http: 'HTTP',
+        patron: 'Patron',
         httparty: 'HTTParty'
       }
       if @backends[backend]

--- a/lib/served/backends/http.rb
+++ b/lib/served/backends/http.rb
@@ -17,8 +17,8 @@ module Served
         response = ::HTTP
           .timeout(global: timeout)
           .headers(headers)
-          .put(template.expand(id:       id,
-                               query:    params,
+          .put(template.expand(id: id,
+                               query: params,
                                resource: endpoint).to_s,
                body: body)
         serialize_response(response)
@@ -30,7 +30,7 @@ module Served
         response = ::HTTP
           .timeout(global: timeout)
           .headers(headers)
-          .post(template.expand(query:    params,
+          .post(template.expand(query: params,
                                 resource: endpoint).to_s,
                 body: body)
         serialize_response(response)
@@ -42,9 +42,9 @@ module Served
         response = ::HTTP
           .timeout(global: timeout)
           .headers(headers)
-          .delete(template.expand(query:    params,
+          .delete(template.expand(query: params,
                                   resource: endpoint,
-                                  id:       id).to_s)
+                                  id: id).to_s)
         serialize_response(response)
       rescue ::HTTP::ConnectionError
         raise Served::HTTPClient::ConnectionFailed.new(resource)

--- a/lib/served/backends/httparty.rb
+++ b/lib/served/backends/httparty.rb
@@ -6,8 +6,8 @@ module Served
     # {https://github.com/jnunemaker/httparty HTTParty} client
     class HTTParty < Base
       def get(endpoint, id, params = {})
-        ::HTTParty.get(template.expand(id:       id,
-                                       query:    params,
+        ::HTTParty.get(template.expand(id: id,
+                                       query: params,
                                        resource: endpoint).to_s,
                        headers: headers,
                        timeout: timeout)
@@ -16,10 +16,10 @@ module Served
       end
 
       def put(endpoint, id, body, params = {})
-        ::HTTParty.put(template.expand(id:       id,
-                                       query:    params,
+        ::HTTParty.put(template.expand(id: id,
+                                       query: params,
                                        resource: endpoint).to_s,
-                       body:    body,
+                       body: body,
                        headers: headers,
                        timeout: timeout)
       rescue Errno::ECONNREFUSED
@@ -36,8 +36,8 @@ module Served
       end
 
       def delete(endpoint, id, params = {})
-        ::HTTParty.delete(template.expand(id:       id,
-                                          query:    params,
+        ::HTTParty.delete(template.expand(id: id,
+                                          query: params,
                                           resource: endpoint).to_s,
                           headers: headers,
                           timeout: timeout)

--- a/lib/served/backends/patron.rb
+++ b/lib/served/backends/patron.rb
@@ -7,8 +7,8 @@ module Served
     class Patron < Base
       def get(endpoint, id, params = {})
         serialize_response(::Patron::Session.new(headers: headers, timeout: timeout)
-                               .get(template.expand(id:       id,
-                                                    query:    params,
+                               .get(template.expand(id: id,
+                                                    query: params,
                                                     resource: endpoint).to_s))
       rescue ::Patron::ConnectionFailed
         raise Served::HTTPClient::ConnectionFailed.new(resource)
@@ -16,8 +16,8 @@ module Served
 
       def put(endpoint, id, body, params = {})
         serialize_response(::Patron::Session.new(headers: headers, timeout: timeout)
-                               .put(template.expand(id:       id,
-                                                    query:    params,
+                               .put(template.expand(id: id,
+                                                    query: params,
                                                     resource: endpoint).to_s, body))
       rescue ::Patron::ConnectionFailed
         raise Served::HTTPClient::ConnectionFailed.new(resource)
@@ -25,7 +25,7 @@ module Served
 
       def post(endpoint, body, params = {})
         serialize_response(::Patron::Session.new(headers: headers, timeout: timeout)
-                               .post(template.expand(query:    params,
+                               .post(template.expand(query: params,
                                                      resource: endpoint).to_s, body))
       rescue ::Patron::ConnectionFailed
         raise Served::HTTPClient::ConnectionFailed.new(resource)
@@ -34,8 +34,8 @@ module Served
       def delete(endpoint, id, params = {})
         serialize_response(::Patron::Session.new(headers: headers,
                                                  timeout: timeout)
-                               .delete(template.expand(id:       id,
-                                                       query:    params,
+                               .delete(template.expand(id: id,
+                                                       query: params,
                                                        resource: endpoint).to_s))
       rescue ::Patron::ConnectionFailed
         raise Served::HTTPClient::ConnectionFailed.new(resource)

--- a/lib/served/resource/attributable.rb
+++ b/lib/served/resource/attributable.rb
@@ -19,6 +19,7 @@ module Served
         # @param name [Symbol] the name of the attribute
         def attribute(name, options = {})
           return if attributes.include?(name)
+
           attributes[name] = options
           attr_accessor name
         end
@@ -79,6 +80,7 @@ module Served
       def set_attribute_defaults
         self.class.attributes.each do |attr, options|
           next if options[:default].nil? || send(attr)
+
           set_attribute(attr, options[:default])
         end
       end

--- a/lib/served/resource/configurable.rb
+++ b/lib/served/resource/configurable.rb
@@ -34,6 +34,7 @@ module Served
               instance_variable_set(:"@_c_#{name}", value) if value
               value ||= instance_variable_get(:"@_c_#{name}")
               return instance_eval(&value) if value.is_a? Proc
+
               value
             end
 

--- a/lib/served/resource/configurable.rb
+++ b/lib/served/resource/configurable.rb
@@ -15,7 +15,7 @@ module Served
             super
             instance_variables.each do |v|
               instance = instance_variable_get(v)
-              instance = instance.clone unless instance.is_a? Fixnum
+              instance = instance.clone unless instance.is_a? Integer
               subclass.send(:instance_variable_set, v, instance) if v.to_s =~ /@_c_/
             end
           end

--- a/lib/served/resource/invalid_attribute_serializer.rb
+++ b/lib/served/resource/invalid_attribute_serializer.rb
@@ -1,8 +1,8 @@
 module Served
   module Resource
     class InvalidAttributeSerializer < Served::Error
-      def initialize(s)
-        super "'#{s}' attribute serializer does not exist"
+      def initialize(type)
+        super "'#{type}' attribute serializer does not exist"
       end
     end
   end

--- a/lib/served/resource/requestable.rb
+++ b/lib/served/resource/requestable.rb
@@ -77,6 +77,7 @@ module Served
             if result.respond_to?(:ancestors) && result.ancestors.include?(HttpError)
               raise result.new(response.code, self, response)
             end
+
             result
           else
             serializer.load(self, response)
@@ -92,6 +93,7 @@ module Served
         # @yieldreturn [Hash] a hash of attributes, if an error class is returned it will be raised
         def handle(code_or_range, symbol_or_proc = nil, &block)
           raise HandlerRequired unless symbol_or_proc || block_given?
+
           if code_or_range.is_a?(Range) || code_or_range.is_a?(Array)
             code_or_range.each do |c|
               handlers[c] = symbol_or_proc || block unless handlers.key?(c)
@@ -103,11 +105,11 @@ module Served
 
         # Defines the default headers that should be used for the request.
         #
-        # @param headers [Hash] the headers to send with each requesat
+        # @param request_headers [Hash] the headers to send with each request
         # @return headers [Hash] the default headers for the class
-        def headers(h = {})
+        def headers(request_headers = {})
           headers ||= _headers
-          _headers(headers.merge!(h)) unless h.empty?
+          _headers(headers.merge!(request_headers)) unless request_headers.empty?
           _headers
         end
 

--- a/lib/served/resource/serializable.rb
+++ b/lib/served/resource/serializable.rb
@@ -28,6 +28,7 @@ module Served
             raise ResponseInvalid.new(self, e)
           end
           raise ResponseInvalid.new(self) unless result
+
           result
         end
 
@@ -49,9 +50,11 @@ module Served
           return ->(v) { return v.try(:to_sym) } if type == Symbol
           return ->(v) { return v.try(:to_f)   } if type == Float
           return ->(v) { return v.try(:to_a)   } if type == Array
+
           if type == Boolean
             return lambda do |v|
               return false unless v == "true" || v.is_a?(TrueClass)
+
               true
             end
           end
@@ -66,6 +69,7 @@ module Served
 
         def serialize_attribute(attr, value)
           return false unless attributes[attr.to_sym]
+
           serializer = attribute_serializer_for(attributes[attr.to_sym][:serialize])
           if value.is_a? Array
             # TODO: Remove the Array class check below in 1.0, only here

--- a/lib/served/resource/serializable.rb
+++ b/lib/served/resource/serializable.rb
@@ -44,7 +44,7 @@ module Served
         def attribute_serializer_for(type)
           # case statement wont work here because of how it does class matching
           return ->(v) { return v }              unless type # nil
-          return ->(v) { return v.try(:to_i)   } if type == Integer || type == Fixnum
+          return ->(v) { return v.try(:to_i)   } if type == Integer
           return ->(v) { return v.try(:to_s)   } if type == String
           return ->(v) { return v.try(:to_sym) } if type == Symbol
           return ->(v) { return v.try(:to_f)   } if type == Float

--- a/lib/served/resource/validatable.rb
+++ b/lib/served/resource/validatable.rb
@@ -34,6 +34,7 @@ module Served
       module Prepend
         def save(with_validations = true)
           return false if with_validations && self.class.validate_on_save && !valid?
+
           super()
         end
 

--- a/lib/served/serializers/json_api.rb
+++ b/lib/served/serializers/json_api.rb
@@ -71,6 +71,7 @@ module Served
         data['relationships'].each_key do |relationship|
           rel = data['relationships'][relationship]
           next unless rel && rel['data']
+
           rel_data = rel['data']
 
           relationship_attributes = if rel_data.is_a?(Array)

--- a/lib/served/serializers/json_api/error.rb
+++ b/lib/served/serializers/json_api/error.rb
@@ -46,7 +46,7 @@ module Served
 
         def source
           res = attrs.fetch(:source, {})
-          res ? res : {}
+          res || {}
         end
 
         protected

--- a/lib/served/version.rb
+++ b/lib/served/version.rb
@@ -1,3 +1,3 @@
 module Served
-  VERSION = '0.4.3'.freeze
+  VERSION = '0.4.4'.freeze
 end

--- a/served.gemspec
+++ b/served.gemspec
@@ -1,8 +1,9 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'served/version'
 
 Gem::Specification.new do |spec|
+  spec.required_ruby_version = '>= 2.4.0'
   spec.name          = 'served'
   spec.version       = Served::VERSION
   spec.authors       = ['Jarod Reid']

--- a/served.gemspec
+++ b/served.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 3.2'
   spec.add_dependency 'addressable',   '>= 2.4.0'
 
-  spec.add_development_dependency 'bundler',  '~> 1.10'
+  spec.add_development_dependency 'bundler',  '~> 2.2.0'
   spec.add_development_dependency 'http',     '~> 1.0.4'
   spec.add_development_dependency 'httparty', '~> 0.14.0'
   spec.add_development_dependency 'patron',   '~> 0.5.0'

--- a/spec/resource/serializable_spec.rb
+++ b/spec/resource/serializable_spec.rb
@@ -128,7 +128,7 @@ describe Served::Resource::Serializable do
               @field = field
             end
 
-            def to_json
+            def to_json(*_args)
               { field: @field }.to_json
             end
           end.new(field)

--- a/spec/resource/serializable_spec.rb
+++ b/spec/resource/serializable_spec.rb
@@ -14,7 +14,7 @@ describe Served::Resource::Serializable do
       end
 
       include Served::Resource::Serializable
-      attribute :fixnum,  serialize: Fixnum
+      attribute :fixnum,  serialize: Integer
       attribute :string,  serialize: String
       attribute :symbol,  serialize: Symbol
       attribute :float,   serialize: Float

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'served'
 require 'served/backends/http'
 require 'served/backends/httparty'


### PR DESCRIPTION
Ticket: DT-4008

Description: In inventory (and anywhere else we use Served) we constantly get:
```
served-9ebcbc980339/lib/served/resource/serializable.rb:47: warning: constant ::Fixnum is deprecated
```
That is because with ruby [2.4.0 release](https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/) Fixnum was unified into Integer.